### PR TITLE
Upgrade bamboo to 5.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+2014-09-01 22:34:04 -0700 Adam Crews 
+
+	* Upgrade bamboo to 5.6.1 (HEAD, bamboo_upgrade)
+
 2014-08-29 17:07:59 -0700 Adam Crews 
 
-	* Fix lint errors so travis is happy (HEAD, travis)
+	* Fix lint errors so travis is happy (origin/travis, travis)
 
 2014-08-29 16:56:50 -0700 Adam Crews 
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,7 @@ class bamboo::params {
 
   $username           = 'bamboo'
   $pass_hash          = undef
-  $bamboo_version     = '5.5.1'
+  $bamboo_version     = '5.6.1'
   $bamboo_home        = '/opt/atlassian/bamboo'
   $bamboo_data        = '/var/atlassian/application-data/bamboo'
   $bamboo_url         = 'http://www.atlassian.com/software/bamboo/downloads/binary'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -20,6 +20,7 @@ class bamboo::service inherits bamboo {
       hasstatus  => true,
       hasrestart => true,
       require    => File["/etc/init.d/${service_name}"],
+      subscribe  => File_line['Set bamboo data directory'],
     }
   }
 }

--- a/spec/classes/bamboo_spec.rb
+++ b/spec/classes/bamboo_spec.rb
@@ -8,7 +8,7 @@ end
 describe 'bamboo' do
 
   # Update the bamboo version 
-  bamboo_version = '5.5.1'
+  bamboo_version = '5.6.1'
 
   ['RedHat', 'Debian' ].each do |osfamily|
 


### PR DESCRIPTION
Additionally add a subscribe from the service to the config
file so that the upgrade will trigger a restart of the bamboo
process.
