### PR TITLE
Bump version range for nanilu/staging up to <2.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
       ref: '4.1.0'
     staging:
       repo: 'nanliu/staging'
-      ref:  '0.4.1'
+      ref:  '1.0.3'
     postgresql:
       repo: 'puppetlabs/postgresql'
       ref: '3.4.1'

--- a/metadata.json
+++ b/metadata.json
@@ -50,7 +50,7 @@
     },
     {
       "name": "nanliu/staging",
-      "version_requirement": ">=0.4.1 <1.0.0"
+      "version_requirement": ">=0.4.1 <2.0.0"
     },
     {
       "name": "puppetlabs/java",


### PR DESCRIPTION
Looking at the [diff between 0.4.1 and 1.0.0](https://github.com/nanliu/puppet-staging/compare/0.4.1...1.0.0), there were no breaking changes, only support for S3 was added.

Even the [diff between 0.4.1 and master](https://github.com/nanliu/puppet-staging/compare/0.4.1...master) doesn't highlight any blockers.
